### PR TITLE
added support for tracking 'Content-Length' via res.writeHead

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,12 @@ function accesslog(req, res, format, cb) {
       reason = null;
     }
 
-    if (headers && 'Content-Length' in headers) {
-      res.contentLength = headers["Content-Length"];
+    if (headers) {
+      for (var k in headers) {
+        if (k.toLowerCase() == "content-length") {
+          res.contentLength = headers[k];
+		}
+	  }
     }
   };
   


### PR DESCRIPTION
Usage of res.writeHead is very common prior to "end", so this override will allow the tracking of 'Content-Length' so it is not lost if header is already written.
